### PR TITLE
chore(package): add "engines" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "argv"
   ],
   "author": "André Cruz <andre@moxy.studio>",
+  "engines": {
+    "node": ">=6"
+  },
   "homepage": "https://github.com/yargs/yargs-unparser",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add "engines" property to package.json,
because the package doesn't work for nodejs below v6:

```
$ node -v
v5.12.0

$ node index.js
D:\projects\yargs-unparser\index.js:56
        const { 0: cmd, index } = options.command.match(/[^<[]*/);
              ^

SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:148:18)
    at node.js:405:3
```

Object destructuring expression is supported from nodejs `v6.0.0`:
https://node.green/
