### PR TITLE
Better performance by eliminating a bunch of unnecessary filesystem calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,7 @@
 
 const yargs = require('yargs/yargs');
 const flatten = require('flat');
-const castArray = require('lodash/castArray');
-const some = require('lodash/some');
-const isPlainObject = require('lodash/isPlainObject');
-const camelCase = require('lodash/camelCase');
-const kebabCase = require('lodash/kebabCase');
-const omitBy = require('lodash/omitBy');
+const {castArray, some, isPlainObject, camelCase, kebabCase, omitBy} = require('lodash/lodash.min');
 
 function isAlias(key, alias) {
     return some(alias, (aliases) => castArray(aliases).indexOf(key) !== -1);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const yargs = require('yargs/yargs');
 const flatten = require('flat');
-const {castArray, some, isPlainObject, camelCase, kebabCase, omitBy} = require('lodash/lodash.min');
+const {castArray, some, isPlainObject, camelCase, kebabCase, omitBy} = require('lodash');
 
 function isAlias(key, alias) {
     return some(alias, (aliases) => castArray(aliases).indexOf(key) !== -1);


### PR DESCRIPTION
Here's an easy benchmark that shows loading a single lodash file is faster than loading a bunch of different ones.  Node's module resolution logic means that even simple module loading can require many filesystem calls.

```
# I used the official node docker image to keep things simple
docker run -i --tty --entrypoint /bin/sh node

# Install lodash
yarn add lodash

# Try both styles of loading lodash: loading from a single file, and loading from multiple files
# Log timing info
for i in 1 2 3 4 5 6 7 8 9 10 ; do
  node -e 'console.time(process.argv[1]);for(const a of process.argv.slice(2))require(a);console.timeEnd(process.argv[1]);' 'one ' lodash/lodash.min
  node -e 'console.time(process.argv[1]);for(const a of process.argv.slice(2))require(a);console.timeEnd(process.argv[1]);' many lodash/castArray lodash/some lodash/isPlainObject lodash/camelCase lodash/kebabCase lodash/omitBy
done
```