### PR TITLE
This fixes a bug with camelCased flattened keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ function unparseOption(key, value, unparsed) {
         const flattened = flatten(value, { safe: true });
 
         for (const flattenedKey in flattened) {
-            unparseOption(`${key}.${flattenedKey}`, flattened[flattenedKey], unparsed);
+            if (!isCamelCased(flattenedKey, flattened)) {
+                unparseOption(`${key}.${flattenedKey}`, flattened[flattenedKey], unparsed);
+            }
         }
     // Fallback case (numbers and other types)
     } else if (value != null) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -80,6 +80,18 @@ it('should keep camel-cased keys if standard ones were not found on argv', () =>
     expect(unparse(argv)).toEqual(['--someNumber', '1']);
 });
 
+it('should not duplicate nested keys that are camel-cased', () => {
+    const argv = parse(['--paths.some-string', 'foo']);
+
+    expect(unparse(argv)).toEqual(['--paths.some-string', 'foo']);
+});
+
+it('should keep nested camel-cased keys if standard ones were not found on argv', () => {
+    const argv = parse(['--paths.someNumber', '1']);
+
+    expect(unparse(argv)).toEqual(['--paths.someNumber', '1']);
+});
+
 it('should ignore nullish option values', () => {
     const argv = parse(['node', 'cli.js'], {
         number: 'n',


### PR DESCRIPTION
i was unparsing paths.somePath and paths.some-path and getting duplicates.

this seems to fix it.