### PR TITLE
Split lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@
 
 const yargs = require('yargs/yargs');
 const flatten = require('flat');
-const castArray = require('lodash/castArray');
-const some = require('lodash/some');
-const isPlainObject = require('lodash/isPlainObject');
-const camelCase = require('lodash/camelCase');
-const kebabCase = require('lodash/kebabCase');
-const omitBy = require('lodash/omitBy');
+const castArray = require('lodash.castarray');
+const some = require('lodash.some');
+const isPlainObject = require('lodash.isplainobject');
+const camelCase = require('lodash.camelcase');
+const kebabCase = require('lodash.kebabcase');
+const omitBy = require('lodash.omitby');
 
 function isAlias(key, alias) {
     return some(alias, (aliases) => castArray(aliases).indexOf(key) !== -1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5979,7 +5979,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -5990,14 +5991,22 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
-      "dev": true
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
     },
     "lodash.merge": {
       "version": "4.6.1",
@@ -6017,6 +6026,11 @@
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
+    },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
@@ -6028,6 +6042,11 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
       "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,12 @@
   },
   "dependencies": {
     "flat": "^4.1.0",
-    "lodash": "^4.17.11",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.castarray": "^4.4.0",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.kebabcase": "^4.1.1",
+    "lodash.omitby": "^4.6.0",
+    "lodash.some": "^4.6.0",
     "yargs": "^12.0.5"
   }
 }


### PR DESCRIPTION
This pull request decreases the size of the `yargs-unparser` module and means dependents are less likely to be notified of irrelevant lodash security vulnerabilities.

__Background__

I was recently notified of a vulnerability, because `mocha` uses `yargs-unparser` and `yargs-unparser` uses `lodash`, but the [vulnerability](https://www.npmjs.com/advisories/1065) only affects `lodash/defaultsDeep`, which `yargs-unparser` doesn't use.
