### PR TITLE
refactor: drop lodash some, castArray and omitBy

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@
 
 const yargs = require('yargs/yargs');
 const flatten = require('flat');
-const { isPlainObject, camelCase, kebabCase } = require('lodash');
+const camelcase = require('camelcase');
+const decamelize = require('decamelize');
+const { isPlainObject } = require('lodash');
 
 function isAlias(key, alias) {
     // TODO Switch to Object.values one Node.js 6 is dropped
@@ -14,8 +16,8 @@ function hasDefaultValue(key, value, defaults) {
 }
 
 function isCamelCased(key, argv) {
-    return /[A-Z]/.test(key) && camelCase(key) === key && // Is it camel case?
-        argv[kebabCase(key)] != null; // Is the standard version defined?
+    return /[A-Z]/.test(key) && camelcase(key) === key && // Is it camel case?
+        argv[decamelize(key, '-')] != null; // Is the standard version defined?
 }
 
 function keyToFlag(key) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const yargs = require('yargs/yargs');
 const flatten = require('flat');
 const camelcase = require('camelcase');
 const decamelize = require('decamelize');
-const { isPlainObject } = require('lodash');
+const isPlainObj = require('is-plain-obj');
 
 function isAlias(key, alias) {
     // TODO Switch to Object.values one Node.js 6 is dropped
@@ -33,7 +33,7 @@ function unparseOption(key, value, unparsed) {
         unparsed.push(`--no-${key}`);
     } else if (Array.isArray(value)) {
         value.forEach((item) => unparseOption(key, item, unparsed));
-    } else if (isPlainObject(value)) {
+    } else if (isPlainObj(value)) {
         const flattened = flatten(value, { safe: true });
 
         for (const flattenedKey in flattened) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4648,8 +4648,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "camelcase": "^5.3.1",
     "decamelize": "^1.2.0",
     "flat": "^4.1.0",
-    "lodash": "^4.17.15",
+    "is-plain-obj": "^1.1.0",
     "yargs": "^13.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "yargs-parser": "^13.1.1"
   },
   "dependencies": {
+    "camelcase": "^5.3.1",
+    "decamelize": "^1.2.0",
     "flat": "^4.1.0",
     "lodash": "^4.17.15",
     "yargs": "^13.3.0"

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -130,10 +130,15 @@ describe('options', () => {
         const alias = {
             string: 's', // Single alias
             number: ['n', 'no'], // Multiple aliases
+            substr: 'substring',
         };
-        const argv = parse(['--string', 'foo', '--number', '1'], { alias });
+        const argv = parse(['--string', 'foo', '--number', '1', '--substr', 'a'], { alias });
 
-        expect(unparse(argv, { alias })).toEqual(['--string', 'foo', '--number', '1']);
+        expect(unparse(argv, { alias })).toEqual([
+            '--string', 'foo',
+            '--number', '1',
+            '--substr', 'a',
+        ]);
     });
 
     it('should filter flags with default values via `options.defaults`', () => {


### PR DESCRIPTION
I am thinking lodash.camelCase and lodash.kebabCase should probably be replaced with camelcase and decamelize which is used by yargs-parser.  Should be possible to use `is-plain-obj` or `is-plain-object` which would eliminate lodash.