### PR TITLE
fix(security): upgraded flat to version ^5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2357,12 +2357,9 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -2936,11 +2933,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "camelcase": "^5.3.1",
     "decamelize": "^1.2.0",
-    "flat": "^4.1.0",
+    "flat": "^5.0.2",
     "is-plain-obj": "^1.1.0",
     "yargs": "^14.2.3"
   }


### PR DESCRIPTION
The package flat has deprecated many of its versions due to a known vulnerability regarding prototype pollution. The previously used version, `4.1.0`, was one of the many versions that were deprecated. As far as this package is concerned however, upgrading to `5.0.2` should cause no issues as the `flatten` method did not experience a breaking change in the major version change. 