### PR TITLE
feat(options): add delimiter for unparse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "yargs-unparser",
+  "name": "yargs-unparser-bak",
   "description": "Converts back a yargs argv object to its original array form",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "keywords": [
     "yargs",
     "unparse",
@@ -9,12 +9,12 @@
     "inverse",
     "argv"
   ],
-  "author": "André Cruz <andre@moxy.studio>",
+  "author": "gemwuu <gemwuu@github.com>",
   "engines": {
     "node": ">=10"
   },
-  "homepage": "https://github.com/yargs/yargs-unparser",
-  "repository": "yargs/yargs-unparser",
+  "homepage": "https://github.com/gemwuu/yargs-unparser.git",
+  "repository": "gemwuu/yargs-unparser",
   "license": "MIT",
   "main": "index.js",
   "files": [],

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -219,3 +219,26 @@ describe('interoperation with other libraries', () => {
         });
     });
 });
+
+describe('use equal mark as delimiter', () => {
+    it('should success', () => {
+        const argv = parse(['--no-cache', '--optimize', '--host', '0.0.0.0', '--collect', 'x', 'y', '--env', 'node', '--env', 'python'], {
+            boolean: ['cache', 'optimize'],
+            string: 'host',
+            array: ['collect', 'env'],
+        });
+        const argvArray = unparse(argv, {
+            delimiter: '=',
+        });
+
+        expect(argvArray).toEqual(['--no-cache', '--optimize', '--host=0.0.0.0', '--collect=x', '--collect=y', '--env=node', '--env=python']);
+
+        expect(minimist(argvArray)).toMatchObject({
+            cache: false,
+            optimize: true,
+            host: '0.0.0.0',
+            collect: ['x', 'y'],
+            env: ['node', 'python'],
+        });
+    });
+});


### PR DESCRIPTION
for `npm i --env_type=1 --env_arg 2`, we need an option to unparse to `npm i --env_type=1 --env_arg=2`, otherwise npm will treat `2` as an npm package.

Usage: `unparse(args, { delimiter: '=' })`;